### PR TITLE
Fix improper call to initFromJSON in launch_board

### DIFF
--- a/gui/src/qwidgets/core.py
+++ b/gui/src/qwidgets/core.py
@@ -61,7 +61,8 @@ class MainWindow(QWidget):
     def launch_board(self, selected_json):
         """Called when a JSON file is selected to load the board"""
         board = PluginManager()
-        board.initFromJSON(selected_json)
+        ## I think Current Commit has an improper call
+        board.initFromJSON(self, selected_json)
         startModHost()
         modhost = connectToModHost()
         if modhost is None:


### PR DESCRIPTION
Correct the method call to include 'self' in 'initFromJSON'.